### PR TITLE
Add JSHint config file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+  // Enforcing options, without name - set to false to ignore violations
+  "-W017": false, // 'Bad operand.'
+  "-W030": false, // 'Expected an assignment or function call and instead saw an expression.'
+  "-W058": false, // 'Missing '()' invoking a constructor.'
+
+  // Relaxing options - set to true to ignore violations
+  "asi": true,
+  "boss": true,
+  "laxcomma": true,
+  "shadow": true,
+
+  // Environments - set to true to allow environment variables
+  "browser": true,
+  "node": true
+}


### PR DESCRIPTION
This helps make sure all contributors follow the same coding conventions and can find potential bugs.

I've turned off anything that gives an error or warning on the existing code. But there's one error I couldn't turn off:
`inflate.js: line 465, col 18, Variable codes_symbol was not declared correctly. (E038)`

You might want to take a look at those turned off options though because some of them make sense to turn back on IMHO.

```
# install jshint
npm install jshint -g

# run jshint, config file is found automatically when it's in the same folder
jshint *.js
```

Linting can be automated with GruntJS, WebStorm IDE or some other build tool. It can also be connected to Travis so that all Pull Requests are automatically checked.
