### PR TITLE
Fix blob type checking in object-codec

### DIFF
--- a/lib/object-codec.js
+++ b/lib/object-codec.js
@@ -26,7 +26,7 @@ function encodeBlob(body) {
   // Assume strings are normal unicode strings
   if (typeof body === "string") return bodec.fromUnicode(body);
   if (Array.isArray(body)) return bodec.fromArray(body);
-  if (bodec.isBinary) return body;
+  if (bodec.isBinary(body)) return body;
   throw new Error("Invalid body for blob");
 }
 

--- a/test/test-object-codec.js
+++ b/test/test-object-codec.js
@@ -19,6 +19,24 @@ run([
       throw new Error("Invalid blob hash");
     }
   },
+  function testEncodeBlobInvalidType() {
+    var correctExceptionThrown = false;
+    blob = {
+      thisis: 'Not array, binary, or text'
+    };
+    try {
+      blobBin = codec.frame({type: "blob", body: blob});
+    }
+    catch (exception) {
+      if (/invalid body/i.test(exception.message)) {
+        correctExceptionThrown = true;
+      }
+    }
+
+    if (!correctExceptionThrown) {
+      throw new Error("Expected the correct exception when the blog was an invalid type");
+    }
+  },
   function testEncodeTree() {
     tree = {
       "greeting.txt": {


### PR DESCRIPTION
In object-codec's encodeBlob method, fix the error message for when an
invalid body is sent. It was something cryptic about missing methods; now
it is the expected "Invalid body for blob".
