### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ var commit = yield repo.loadAs("commit", commitHash);
 // We then read the tree using `commit.tree`.
 var tree = yield repo.loadAs("tree", commit.tree);
 // We then read the file using the entry hash in the tree.
-var file = yield repo.loadAs("blob", tree["greeting.txt"]);
+var file = yield repo.loadAs("blob", tree["greeting.txt"].hash);
 // file is now a binary buffer.
 ```
 


### PR DESCRIPTION
`repo.loadAs()` expects a hash as the second parameter.

Using the callback api, repo.loadAs() expects a hash as the second parameter. It calls back with an empty array if the `tree["greeting.txt"]`object is passed. In my opinion, it should callback with an error if the hash is not valid.
