### PR TITLE
Portable octal representation

### DIFF
--- a/lib/modes.js
+++ b/lib/modes.js
@@ -1,21 +1,28 @@
-// Not strict mode because it uses octal literals all over.
-module.exports = {
+"use strict";
+
+var masks = {
+  mask:   parseInt('100000', 8),
+  blob:   parseInt('140000', 8),
+  file:   parseInt('160000', 8)
+};
+
+var modes = module.exports = {
   isBlob: function (mode) {
-    return (mode & 0140000) === 0100000;
+    return (mode & masks.blob) === masks.mask;
   },
   isFile: function (mode) {
-    return (mode & 0160000) === 0100000;
+    return (mode & masks.file) === masks.mask;
   },
   toType: function (mode) {
-    if (mode === 0160000) return "commit";
-    if (mode ===  040000) return "tree";
-    if ((mode & 0140000) === 0100000) return "blob";
+    if (mode === modes.commit) return "commit";
+    if (mode === modes.tree) return "tree";
+    if ((mode & masks.blob) === masks.mask) return "blob";
     return "unknown";
   },
-  tree:    040000,
-  blob:   0100644,
-  file:   0100644,
-  exec:   0100755,
-  sym:    0120000,
-  commit: 0160000
+  tree:   parseInt( '40000', 8),
+  blob:   parseInt('100644', 8),
+  file:   parseInt('100644', 8),
+  exec:   parseInt('100755', 8),
+  sym:    parseInt('120000', 8),
+  commit: parseInt('160000', 8)
 };


### PR DESCRIPTION
ES6 and prior ES octal notation compatible: https://github.com/creationix/js-git/issues/126
