### PR TITLE
Fix commit ordering and traversal for logWalk

### DIFF
--- a/mixins/walkers.js
+++ b/mixins/walkers.js
@@ -39,6 +39,7 @@ function logWalk(ref, callback) {
     return repo.loadAs("commit", hash, function (err, commit) {
       if (!commit) return callback(err || new Error("Missing commit " + hash));
       commit.hash = hash;
+      seen[hash] = true;
       if (hash === last) commit.last = true;
       return callback(null, commit);
     });
@@ -47,7 +48,7 @@ function logWalk(ref, callback) {
 }
 
 function compare(commit, other) {
-  return commit.author.date < other.author.date;
+  return commit.author.date.seconds > other.author.date.seconds;
 }
 
 function treeWalk(hash, callback) {


### PR DESCRIPTION
The compare function was comparing objects instead of seconds, always returning the same result (false, I believe). I believe it is correct to compare just seconds without the offset, as I believe seconds should be since the Unix epoch which is timezone independent, but I'm not positive. When fixed, it revealed that the seen map was not being updated during the walk, leading to duplicate commits being emitted (would walk down both sides of a merge and then the shared history twice).