### PR TITLE
Fix public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/creationix/js-git.git"
+    "url": "git+https://github.com/creationix/js-git.git"
   },
   "author": "Tim Caswell <tim@creationix.com>",
   "license": "MIT",


### PR DESCRIPTION
This updates the package repository metadata to use a public HTTPS Git URL instead of the legacy `git://github.com` form.

The package is public, so tooling that reads `repository.url` can inspect or clone it over HTTPS without legacy git protocol handling.

Validation performed:
- `package.json` parses as JSON
- direct Node assertion confirms `repository.url === git+https://github.com/creationix/js-git.git`
- GitHub compare shows this PR changes only `package.json`

No runtime code, dependency, version, or package entrypoint changes.